### PR TITLE
fix contains deprecation

### DIFF
--- a/addon/handler-config.js
+++ b/addon/handler-config.js
@@ -2,29 +2,29 @@ import Ember from 'ember';
 const { assert } = Ember;
 
 export default class HandlerConfig {
-  
+
   constructor() {
     var args = [...arguments];
     assert("Expects 2 to 4 arguments: event, root (optional), selector (optional) and callback", args.length > 1 && args.length < 5);
 
     this.func = args.pop();
     assert("Last argument must be a callback function", typeof this.func === 'function');
-  
+
     this.event = args.shift();
     assert("Event argument must be a string", typeof this.event === 'string');
 
     this.root = args.shift();
-    if (Ember.A(['component', 'body', 'window']).contains(this.root)) {
-      this.selector = args.pop();      
+    if (Ember.A(['component', 'body', 'window']).includes(this.root)) {
+      this.selector = args.pop();
     } else {
       this.selector = this.root;
       this.root = 'component';
     }
-    assert("Element argument must be a string or undefined", Ember.A(['string', 'undefined']).contains(typeof this.selector));
-    
-    this.auto = true;   
+    assert("Element argument must be a string or undefined", Ember.A(['string', 'undefined']).includes(typeof this.selector));
+
+    this.auto = true;
   }
-  
+
   setManual() {
     this.auto = false;
     return this;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-polyfill-for-tests": "^0.2.0",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "events"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Use [polyfill](https://github.com/rwjblue/ember-runtime-enumerable-includes-polyfill) for backwards compatibility.